### PR TITLE
Explicitly set `_JAVA_OPTIONS` before calling Picard

### DIFF
--- a/modules/postalign_bam.bds
+++ b/modules/postalign_bam.bds
@@ -81,6 +81,10 @@ string[] _dedup_bam( string bam, string o_dir, string log_o_dir, string label ) 
 
 		sys samtools sort $filt_bam.tmp $filt_bam_prefix
 		sys rm -f $filt_bam.tmp
+		
+		//# Set Java environment variable with Xmx, because JVM will ignore our
+		//# runtime flag and use this if it has been set.
+		sys export _JAVA_OPTIONS="-Xms256M -Xmx4G -XX:ParallelGCThreads=1"
 
 		//# Mark duplicates
 		sys if [ -f ${PICARDROOT}/MarkDuplicates.jar ]; then \


### PR DESCRIPTION
If a user has `_JAVA_OPTIONS` set, at runtime JVM will ignore our `-Xmx4G` flag and use the user's setting. Due to unpredictable picard heap space, this was causing unreproducible crashes for me. To fix, we can explicitly set `_JAVA_OPTIONS` before calling Picard, just like we do in atac.bds: https://github.com/kundajelab/bds_atac/blob/master/atac.bds#L814