### PR TITLE
Update bgd to bw conversion in callpeak_macs2.bds

### DIFF
--- a/modules/callpeak_macs2.bds
+++ b/modules/callpeak_macs2.bds
@@ -113,7 +113,7 @@ string[] _macs2( string tag, string ctl_tag, string fraglen, bool make_sig, \
 			slopBed -i "$prefix"_FE.bdg -g $chrsz -b 0 |   awk '{if ($3 != -1) print $0}' |  bedClip stdin $chrsz $fc_bedgraph; \
 			rm -f "$prefix"_FE.bdg; \
 			\
-			sort -k1,1 -k2,2n $fc_bedgraph > $fc_bedgraph_srt; \
+			LC_COLLATE=C sort -k1,1 -k2,2n $fc_bedgraph > $fc_bedgraph_srt; \
 			bedGraphToBigWig $fc_bedgraph_srt $chrsz $fc_bigwig; \
 			rm -f $fc_bedgraph $fc_bedgraph_srt; \
 			\
@@ -123,7 +123,7 @@ string[] _macs2( string tag, string ctl_tag, string fraglen, bool make_sig, \
 			slopBed -i "$prefix"_ppois.bdg -g $chrsz -b 0 |   awk '{if ($3 != -1) print $0}' |  bedClip stdin $chrsz $peak_o_dir/$prefix_basename.pval.signal.bedgraph; \
 			rm -rf "$prefix"_ppois.bdg; \
 			\
-			sort -k1,1 -k2,2n $pval_bedgraph > $pval_bedgraph_srt; \
+			LC_COLLATE=C sort -k1,1 -k2,2n $pval_bedgraph > $pval_bedgraph_srt; \
 			bedGraphToBigWig $pval_bedgraph_srt $chrsz $pval_bigwig; \
 			\
 			rm -f $pval_bedgraph $pval_bedgraph_srt; \


### PR DESCRIPTION
The bedgraph to BigWig conversion step throws an error on my system for all my files:
`(...)pooled.tagAlign.fc.signal.srt.bedgraph is not case-sensitive sorted at line 1879.  Please use "sort -k1,1 -k2,2n" with LC_COLLATE=C,  or bedSort and try again.`
As mentioned in the error message and at [https://gist.github.com/taoliu/2469050](https://gist.github.com/taoliu/2469050), using `LC_COLLATE=C` fixes the issue on my system when the command is ran separately (outside of chipseq.bds pipeline).

Would this addition cause conflict with the rest of the code?

Thanks,