### PR TITLE
Merge sambamba branch

### DIFF
--- a/modules/postalign_bam.bds
+++ b/modules/postalign_bam.bds
@@ -42,7 +42,7 @@ void init_postalign_bam() {
 
 	wt_dedup 	= get_conf_val( wt_dedup, 		["wt_dedup"] )
 	mem_dedup 	= get_conf_val( mem_dedup, 		["mem_dedup"] )
-	use_sambamba_markdup	= get_conf_val( use_sambamba_markdup, ["use_sambamba_markdup"] )
+	use_sambamba_markdup	= get_conf_val_bool( use_sambamba_markdup, ["use_sambamba_markdup"] )
 
 	print("\n\n== postalign bam settings\n")
 	print( "MAPQ reads rm thresh.\t\t: $mapq_thresh\n")
@@ -165,6 +165,7 @@ string[] _dedup_bam( string bam, string o_dir, string log_o_dir, string label, i
 
 		// remove all intermediate files
 		dupmark_bam.rm()
+		sys rm -f dupmark_bam.bai
 		filt_bam.rm()
 		tmp_filt_bam.rm()
 	}
@@ -306,6 +307,7 @@ string[] _dedup_bam_PE( string bam, string o_dir, string log_o_dir, string label
 			sys rm -f $filt_bam.tmp.bam
 
 			sys rm -f $filt_bam
+			sys rm -f $filt_bam.bai
 			sys rm -f $tmp_filt_bam
 
 			sys $shcmd_finalize
@@ -397,6 +399,8 @@ string[] _markdup_bam_sambamba( string bam, string o_dir, string log_o_dir, stri
 		sys sambamba markdup -t $cpus --hash-table-size=17592186044416 \
 			--overflow-list-size=20000000 --io-buffer-size=256 $bam $dupmark_bam \
 			2> $dup_qc
+
+		sys rm -f $dupmark_bam.bai
 
 		sys $shcmd_finalize
 	}

--- a/modules/postalign_bam.bds
+++ b/modules/postalign_bam.bds
@@ -14,6 +14,8 @@ rm_chr_from_tag := "" 		help If specified, exclude lines with specified string f
 wt_dedup 	:= "23h" 	help Walltime for post-alignment filtering (default: 23h, 24:00:00).
 mem_dedup	:= "20G" 	help Max. memory for post-alignment filtering (default: 20G).
 
+use_sambamba_markdup	:= false	help Use sambamba markdup instead of Picard MarkDuplicates (default: false).
+
 /*
 IMPORTANT!: legacy softwares compatibility (make the code work with legacy samtools, picard-tools)
 
@@ -47,6 +49,7 @@ void init_postalign_bam() {
 	print( "Rm. tag reads with str.\t\t: $rm_chr_from_tag\n")
 	print( "Walltime (bam filter)\t: $wt_dedup\n")
 	print( "Max. memory (bam filter)\t: $mem_dedup\n")
+	print( "Use sambamba markdup (instead of picard)\t: $use_sambamba_markdup\n")
 }
 
 string[] _dedup_bam( string bam, string o_dir, string log_o_dir, string label, int nth_dedup ) {

--- a/modules/postalign_bam.bds
+++ b/modules/postalign_bam.bds
@@ -69,84 +69,105 @@ string[] _dedup_bam( string bam, string o_dir, string log_o_dir, string label, i
 	// multimapping
 	qname_sort_bam 	:= "$prefix.qnmsrt.bam"
 
+	// in -> dedup_bam1 -> temp and then temp -> dedup_bam2 -> out
 	in	:= [ bam ]
 	out	:= [ nodup_bam, dup_qc, map_qc, pbc_qc ]
 
-	taskName:= "dedup_bam " + label
 	cpus 	:= nth_dedup; 	mem := get_res_mem(mem_dedup,nth_dedup);	timeout := get_res_wt(wt_dedup)
 
-	wait_par( cpus )
+	if ( out<-in ) {
 
-	tid := task( out<-in ) {
+		taskName:= "dedup_bam_1 " + label
+		in1 	:= in
+		out1 	:= [ filt_bam ]
 
-		sys $shcmd_init
+		wait_par( cpus )
 
-		//# =============================
-		//# Remove  unmapped, mate unmapped
-		//# not primary alignment, reads failing platform
-		//# Remove low MAPQ reads
-		//# ==================
+		tid := task( out1<-in1 ) {
 
-		sys if [[ $multimapping > 0 ]]; then \
-			sambamba sort -t $nth_dedup $bam -n -o $qname_sort_bam; \
-			samtools view -h $qname_sort_bam | $(which assign_multimappers.py) -k $multimapping | \
-			samtools view -F 1804 -Su /dev/stdin | \
-			sambamba sort -t $nth_dedup /dev/stdin -o $filt_bam; \
-			rm -f $qname_sort_bam; \
-		    else \
-		    	samtools view -F 1804 -q $mapq_thresh -u $bam | \
-		    	sambamba sort -t $nth_dedup /dev/stdin -o $filt_bam; \
-		    fi
+			sys $shcmd_init
 
+			//# =============================
+			//# Remove  unmapped, mate unmapped
+			//# not primary alignment, reads failing platform
+			//# Remove low MAPQ reads
+			//# ==================
+
+			sys if [[ $multimapping > 0 ]]; then \
+				sambamba sort -t $nth_dedup $bam -n -o $qname_sort_bam; \
+				samtools view -h $qname_sort_bam | $(which assign_multimappers.py) -k $multimapping | \
+				samtools view -F 1804 -Su /dev/stdin | \
+				sambamba sort -t $nth_dedup /dev/stdin -o $filt_bam; \
+				rm -f $qname_sort_bam; \
+			    else \
+			    	samtools view -F 1804 -q $mapq_thresh -u $bam | \
+			    	sambamba sort -t $nth_dedup /dev/stdin -o $filt_bam; \
+			    fi
+
+			sys $shcmd_finalize
+		}
+
+		register_par( tid, cpus )
+
+		wait // wait for filt_bam
+
+		string dupmark_bam, dup_qc
+
+		if ( use_sambamba_markdup ) {
+
+			(dupmark_bam, dup_qc) = _markdup_bam_sambamba(filt_bam, o_dir, log_o_dir, label, cpus)
+		} else {
+
+			(dupmark_bam, dup_qc) = _markdup_bam_picard(filt_bam, o_dir, log_o_dir, label, cpus)
+		}
+
+		wait // wait for dupmark_bam and dup_qc
+
+		taskName= "dedup_bam_2 " + label
+		in2  := [ dupmark_bam ]
+		out2 := [ nodup_bam, map_qc, pbc_qc ]
+
+		wait_par( cpus )
+
+		tid2 := task( out2<-in2 ) {
+
+			sys $shcmd_init
+
+			//# Remove duplicates
+			//# Index final position sorted BAM
+			sys mv $dupmark_bam $filt_bam
+			sys samtools view -F 1804 -b $filt_bam > $nodup_bam
+
+			//# Index Final BAM file
+			sys sambamba index -t $nth_dedup $nodup_bam
+
+			sys sambamba flagstat -t $nth_dedup $nodup_bam > $map_qc
+
+			//# =============================
+			//# Compute library complexity
+			//# =============================
+			//# sort by position and strand
+			//# Obtain unique count statistics
+
+			//# PBC File output
+			//# TotalReadPairs [tab] DistinctReadPairs [tab] OneReadPair [tab] TwoReadPairs [tab] NRF=Distinct/Total [tab] PBC1=OnePair/Distinct [tab] PBC2=OnePair/TwoPair
+			sys bedtools bamtobed -i $filt_bam | \
+				awk 'BEGIN{OFS="\t"}{print $1,$2,$3,$6}' | \
+				grep -v 'chrM' | sort | uniq -c | \
+				awk 'BEGIN{mt=0;m0=0;m1=0;m2=0} ($1==1){m1=m1+1} ($1==2){m2=m2+1} {m0=m0+1} {mt=mt+$1} END{printf "%d\t%d\t%d\t%d\t%f\t%f\t%f\n",mt,m0,m1,m2,m0/mt,m1/m0,m1/m2}' > $pbc_qc
+
+			sys $shcmd_finalize
+		}
+
+		register_par( tid2, cpus )
+
+		wait // wait for final bam
+
+		// remove all intermediate files
+		dupmark_bam.rm()
+		filt_bam.rm()
+		tmp_filt_bam.rm()
 	}
-
-	register_par( tid, cpus )
-
-	dupmark_bam := "none"
-	dup_qc := "none"
-
-	if ( use_sambamba_markdup ) {
-		(dupmark_bam, dup_qc) = _markdup_bam_sambamba(filt_bam, o_dir, log_o_dir, label, cpus)
-	} else {
-		(dupmark_bam, dup_qc) = _markdup_bam_picard(filt_bam, o_dir, log_o_dir, label, cpus)
-	}
-
-	wait_par( cpus )
-
-	tid2 := task( out<-in ) {
-
-		sys $shcmd_init
-
-		//# Remove duplicates
-		//# Index final position sorted BAM
-		sys mv $dupmark_bam $filt_bam
-		sys samtools view -F 1804 -b $filt_bam > $nodup_bam
-
-		//# Index Final BAM file
-		sys sambamba index -t $nth_dedup $nodup_bam
-
-		sys sambamba flagstat -t $nth_dedup $nodup_bam > $map_qc
-
-		//# =============================
-		//# Compute library complexity
-		//# =============================
-		//# sort by position and strand
-		//# Obtain unique count statistics
-
-		//# PBC File output
-		//# TotalReadPairs [tab] DistinctReadPairs [tab] OneReadPair [tab] TwoReadPairs [tab] NRF=Distinct/Total [tab] PBC1=OnePair/Distinct [tab] PBC2=OnePair/TwoPair
-		sys bedtools bamtobed -i $filt_bam | \
-			awk 'BEGIN{OFS="\t"}{print $1,$2,$3,$6}' | \
-			grep -v 'chrM' | sort | uniq -c | \
-			awk 'BEGIN{mt=0;m0=0;m1=0;m2=0} ($1==1){m1=m1+1} ($1==2){m2=m2+1} {m0=m0+1} {mt=mt+$1} END{printf "%d\t%d\t%d\t%d\t%f\t%f\t%f\n",mt,m0,m1,m2,m0/mt,m1/m0,m1/m2}' > $pbc_qc
-
-		sys rm -f $filt_bam
-		sys rm -f $tmp_filt_bam
-
-		sys $shcmd_finalize
-	}
-
-	register_par( tid2, cpus )
 
 	graph_in  := ["bam_($label)"]
 	graph_out := ["filt_bam_($label)"]
@@ -179,102 +200,125 @@ string[] _dedup_bam_PE( string bam, string o_dir, string log_o_dir, string label
 	in 		:= [ bam ]
 	out 		:= [ nodup_bam, dup_qc, map_qc, pbc_qc ]
 
-	taskName:= "dedup_bam_PE " + label
 	cpus 	:= nth_dedup;	mem := get_res_mem(mem_dedup,nth_dedup);	timeout := get_res_wt(wt_dedup)
 
-	wait_par( cpus )
+	if ( out<-in ) {
 
-	tid := task( out<-in ) {
+		taskName:= "dedup_bam_PE_1 " + label
+		in1 	:= in
+		out1 	:= [ filt_bam ]
 
-		sys $shcmd_init
+		wait_par( cpus )
 
-		//# =============================
-		//# Remove  unmapped, mate unmapped
-		//# not primary alignment, reads failing platform
-		//# Remove low MAPQ reads
-		//# Only keep properly paired reads
-		//# Obtain name sorted BAM file
-		//# ==================
+		tid := task( out1<-in1 ) {
 
-		//# Will produce name sorted BAM
-		//# Remove orphan reads (pair was removed)
-		//# and read pairs mapping to different chromosomes
-		//# Obtain position sorted BAM
-		//# Will produce coordinate sorted BAM
+			sys $shcmd_init
 
-		sys if [[ $multimapping > 0 ]]; then \
-			samtools view -F 524 -f 2 -u $bam | \
-			sambamba sort -t $nth_dedup -n /dev/stdin -o $tmp_filt_bam; \
-			samtools view -h $tmp_filt_bam | \
-			$(which assign_multimappers.py) -k $multimapping --paired-end | \
-			samtools fixmate -r /dev/stdin $tmp_filt_bam.fixmate.bam; \
-		    else \
-		    	samtools view -F 1804 -f 2 -q $mapq_thresh -u $bam | \
-		    	sambamba sort -t $nth_dedup -n /dev/stdin -o $tmp_filt_bam; \
-		        samtools fixmate -r $tmp_filt_bam $tmp_filt_bam.fixmate.bam; \
-		    fi
+			//# =============================
+			//# Remove  unmapped, mate unmapped
+			//# not primary alignment, reads failing platform
+			//# Remove low MAPQ reads
+			//# Only keep properly paired reads
+			//# Obtain name sorted BAM file
+			//# ==================
 
-		sys samtools view -F 1804 -f 2 -u $tmp_filt_bam.fixmate.bam | sambamba sort -t $nth_dedup /dev/stdin -o $filt_bam
+			//# Will produce name sorted BAM
+			//# Remove orphan reads (pair was removed)
+			//# and read pairs mapping to different chromosomes
+			//# Obtain position sorted BAM
+			//# Will produce coordinate sorted BAM
 
-		sys rm -f $tmp_filt_bam.fixmate.bam
+			sys if [[ $multimapping > 0 ]]; then \
+				samtools view -F 524 -f 2 -u $bam | \
+				sambamba sort -t $nth_dedup -n /dev/stdin -o $tmp_filt_bam; \
+				samtools view -h $tmp_filt_bam | \
+				$(which assign_multimappers.py) -k $multimapping --paired-end | \
+				samtools fixmate -r /dev/stdin $tmp_filt_bam.fixmate.bam; \
+			    else \
+			    	samtools view -F 1804 -f 2 -q $mapq_thresh -u $bam | \
+			    	sambamba sort -t $nth_dedup -n /dev/stdin -o $tmp_filt_bam; \
+			        samtools fixmate -r $tmp_filt_bam $tmp_filt_bam.fixmate.bam; \
+			    fi
+
+			sys samtools view -F 1804 -f 2 -u $tmp_filt_bam.fixmate.bam | sambamba sort -t $nth_dedup /dev/stdin -o $filt_bam
+
+			sys rm -f $tmp_filt_bam.fixmate.bam
+
+			sys $shcmd_finalize
+		}
+
+		register_par( tid, cpus )
+
+		wait
+
+		string dupmark_bam, dup_qc
+
+		if ( use_sambamba_markdup ) {
+
+			(dupmark_bam, dup_qc) = _markdup_bam_sambamba(filt_bam, o_dir, log_o_dir, label, cpus)
+		} else {
+
+			(dupmark_bam, dup_qc) = _markdup_bam_picard(filt_bam, o_dir, log_o_dir, label, cpus)
+		}
+
+		wait
+
+		taskName= "dedup_bam_PE_2 " + label
+		in2  := [ dupmark_bam ]
+		out2 := [ nodup_bam, map_qc, pbc_qc ]
+
+		wait_par( cpus )
+
+		tid2 := task( out2<-in2 ) {
+
+			sys $shcmd_init
+
+			//# ============================
+			//# Remove duplicates
+			//# Index final position sorted BAM
+			//# Create final name sorted BAM
+			//# ============================
+
+			sys mv $dupmark_bam $filt_bam
+
+			sys samtools view -F 1804 -f 2 -b $filt_bam > $nodup_bam
+
+			sys sambamba index -t $nth_dedup $nodup_bam
+
+			sys sambamba flagstat -t $nth_dedup $nodup_bam > $map_qc
+
+			//# =============================
+			//# Compute library complexity
+			//# =============================
+			//# Sort by name
+			//# convert to bedPE and obtain fragment coordinates
+			//# sort by position and strand
+			//# Obtain unique count statistics
+
+			//# TotalReadPairs [tab] DistinctReadPairs [tab] OneReadPair [tab] TwoReadPairs [tab] NRF=Distinct/Total [tab] PBC1=OnePair/Distinct [tab] PBC2=OnePair/TwoPair
+			sys sambamba sort -t $nth_dedup -n $filt_bam -o $filt_bam.tmp.bam
+
+			sys bedtools bamtobed -bedpe -i $filt_bam.tmp.bam | \
+				awk 'BEGIN{OFS="\t"}{print $1,$2,$4,$6,$9,$10}' | \
+				grep -v 'chrM' | sort | uniq -c | \
+				awk 'BEGIN{mt=0;m0=0;m1=0;m2=0} ($1==1){m1=m1+1} ($1==2){m2=m2+1} {m0=m0+1} {mt=mt+$1} END{printf "%d\t%d\t%d\t%d\t%f\t%f\t%f\n",mt,m0,m1,m2,m0/mt,m1/m0,m1/m2}' > $pbc_qc
+
+			sys rm -f $filt_bam.tmp.bam
+
+			sys rm -f $filt_bam
+			sys rm -f $tmp_filt_bam
+
+			sys $shcmd_finalize
+		}
+
+		register_par( tid2, cpus )
+
+		wait
+
+		dupmark_bam.rm()
+		filt_bam.rm()
+		tmp_filt_bam.rm()
 	}
-
-	register_par( tid, cpus )
-
-	dupmark_bam := "none"
-	dup_qc := "none"
-
-	if ( use_sambamba_markdup ) {
-		(dupmark_bam, dup_qc) = _markdup_bam_sambamba(filt_bam, o_dir, log_o_dir, label, cpus)
-	} else {
-		(dupmark_bam, dup_qc) = _markdup_bam_picard(filt_bam, o_dir, log_o_dir, label, cpus)
-	}
-
-	wait_par( cpus )
-
-	tid2 := task( out<-in ) {
-
-		sys $shcmd_init
-
-		//# ============================
-		//# Remove duplicates
-		//# Index final position sorted BAM
-		//# Create final name sorted BAM
-		//# ============================
-
-		sys mv $dupmark_bam $filt_bam
-
-		sys samtools view -F 1804 -f 2 -b $filt_bam > $nodup_bam
-
-		sys sambamba index -t $nth_dedup $nodup_bam
-
-		sys sambamba flagstat -t $nth_dedup $nodup_bam > $map_qc
-
-		//# =============================
-		//# Compute library complexity
-		//# =============================
-		//# Sort by name
-		//# convert to bedPE and obtain fragment coordinates
-		//# sort by position and strand
-		//# Obtain unique count statistics
-
-		//# TotalReadPairs [tab] DistinctReadPairs [tab] OneReadPair [tab] TwoReadPairs [tab] NRF=Distinct/Total [tab] PBC1=OnePair/Distinct [tab] PBC2=OnePair/TwoPair
-		sys sambamba sort -t $nth_dedup -n $filt_bam -o $filt_bam.tmp.bam
-
-		sys bedtools bamtobed -bedpe -i $filt_bam.tmp.bam | \
-			awk 'BEGIN{OFS="\t"}{print $1,$2,$4,$6,$9,$10}' | \
-			grep -v 'chrM' | sort | uniq -c | \
-			awk 'BEGIN{mt=0;m0=0;m1=0;m2=0} ($1==1){m1=m1+1} ($1==2){m2=m2+1} {m0=m0+1} {mt=mt+$1} END{printf "%d\t%d\t%d\t%d\t%f\t%f\t%f\n",mt,m0,m1,m2,m0/mt,m1/m0,m1/m2}' > $pbc_qc
-
-		sys rm -f $filt_bam.tmp.bam
-
-		sys rm -f $filt_bam
-		sys rm -f $tmp_filt_bam
-
-		sys $shcmd_finalize
-	}
-
-	register_par( tid2, cpus )
 
 	graph_in  := ["bam_($label)"]
 	graph_out := ["filt_bam_($label)"]
@@ -286,18 +330,18 @@ string[] _dedup_bam_PE( string bam, string o_dir, string log_o_dir, string label
 	return out
 }
 
-string _markdup_bam_picard( string bam, string o_dir, string log_o_dir, string label, int cpus ) {
+string[] _markdup_bam_picard( string bam, string o_dir, string log_o_dir, string label, int nth_markdup ) {
 
 	prefix 		:= replace_dir( rm_ext( bam, "bam" ), o_dir )
 	prefix2 	:= replace_dir( prefix, log_o_dir )
 	dup_qc 		:= "$prefix2.dup.qc"
 	dupmark_bam 	:= "$prefix.dupmark.bam"
-	dupmark_bam_prefix := "$prefix.dupmark"
 
 	in 		:= [ bam ]
 	out 		:= [ dupmark_bam, dup_qc ]
 
 	taskName:= "markdup_bam_picard " + label
+	cpus 	:= nth_markdup; 	mem := get_res_mem(mem_dedup,nth_markdup);	timeout := get_res_wt(wt_dedup)
 
 	wait_par( cpus )
 
@@ -322,6 +366,8 @@ string _markdup_bam_picard( string bam, string o_dir, string log_o_dir, string l
 				METRICS_FILE="$dup_qc" VALIDATION_STRINGENCY=LENIENT \
 				ASSUME_SORTED=true REMOVE_DUPLICATES=false; \
 			fi
+
+		sys $shcmd_finalize
 	}
 
 	register_par( tid, cpus )
@@ -329,18 +375,18 @@ string _markdup_bam_picard( string bam, string o_dir, string log_o_dir, string l
 	return out
 }
 
-string _markdup_bam_sambamba( string bam, string o_dir, string log_o_dir, string label, int cpus ) {
+string[] _markdup_bam_sambamba( string bam, string o_dir, string log_o_dir, string label, int nth_markdup ) {
 
 	prefix 		:= replace_dir( rm_ext( bam, "bam" ), o_dir )
 	prefix2 	:= replace_dir( prefix, log_o_dir )
 	dup_qc 		:= "$prefix2.dup.qc"
 	dupmark_bam 	:= "$prefix.dupmark.bam"
-	dupmark_bam_prefix := "$prefix.dupmark"
 
 	in 		:= [ bam ]
 	out 		:= [ dupmark_bam, dup_qc ]
 
 	taskName:= "markdup_bam_sambamba " + label
+	cpus 	:= nth_markdup; 	mem := get_res_mem(mem_dedup,nth_markdup);	timeout := get_res_wt(wt_dedup)
 
 	wait_par( cpus )
 
@@ -351,6 +397,8 @@ string _markdup_bam_sambamba( string bam, string o_dir, string log_o_dir, string
 		sys sambamba markdup -t $cpus --hash-table-size=17592186044416 \
 			--overflow-list-size=20000000 --io-buffer-size=256 $bam $dupmark_bam \
 			2> $dup_qc
+
+		sys $shcmd_finalize
 	}
 
 	register_par( tid, cpus )


### PR DESCRIPTION
@leepc12 PTAL - I think this is now ready to merge.

This branch adds a command line option `use_sambamba_markdup` (default `false`, can be set to `true`), which will use sambamba (rather than picard) for marking duplicates. Sambamba assumes all alignments in a given bam file are from the same sequencing library, and does not crash or produce memory errors if bams with sequences from multiple lanes do not have read group headers that differentiate each lane.